### PR TITLE
feat: Logging to stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 R&D
 venv.*
 .vscode
+pyvenv.cfg
+bin/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/coordinator/core/logger.py
+++ b/coordinator/core/logger.py
@@ -12,10 +12,17 @@ if not os.path.exists(LOG_PATH):
 logger = logging.getLogger("tinycell_test-coordinator")
 logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter(LOG_FORMAT)
+
+# Handler for logging to file.
 log_handler = logging.handlers.TimedRotatingFileHandler(
     filename=f"{LOG_PATH}/coordinator-log", when="midnight", backupCount=6
 )
-
 log_handler.setFormatter(formatter)
 log_handler.set_name("log_handler")
 logger.addHandler(log_handler)
+
+# Handler for logging to console.
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(formatter)
+console_handler.set_name("console_handler")
+logger.addHandler(console_handler)


### PR DESCRIPTION
It is desirable to print logs into standard output, since further debugging would be needed in the future. It would be easier to just look at the service logs instead of log files.