### PR TITLE
feat: Add functionality to "repeat" parameter

### DIFF
--- a/coordinator/core/testrequest.py
+++ b/coordinator/core/testrequest.py
@@ -118,16 +118,17 @@ def check_request(request: dict) -> None:
                 ):
                     raise Exception("Target device is already in use!")
 
-            test_process = TestProcess(
-                request_id=request_id,
-                device_name=device_name,
-                device_port=device_port,
-                script_name=script_name,
-                repeat=repeat,
-                interval=interval,
-            )
-            test_process_list.append(test_process)
-            test_process.create()
+            for _ in range(repeat):
+                test_process = TestProcess(
+                    request_id=request_id,
+                    device_name=device_name,
+                    device_port=device_port,
+                    script_name=script_name,
+                    repeat=1,
+                    interval=interval,
+                )
+                test_process_list.append(test_process)
+                test_process.create()
             return f"Test process running on {device_name} is completed!"
 
         # request_type is "delete"


### PR DESCRIPTION
Within this PR, the coordinator creates "repeat" number of TestProcess objects and starts them one by one. Note that, it is not concurrent, yet.